### PR TITLE
docs: add MiniMax as an LLM provider option

### DIFF
--- a/PROVIDER_EXAMPLES.md
+++ b/PROVIDER_EXAMPLES.md
@@ -1,0 +1,32 @@
+# Provider Example Configuration
+
+### OpenAI
+
+```yaml
+llm:
+    provider: openai
+    model: gpt-4
+    api_key: sk-your-openai-api-key
+```
+
+### MiniMax (OpenAI-compatible)
+
+```yaml
+llm:
+    provider: minimax
+    model: openai/MiniMax-M2.5
+    api_key: your-minimax-api-key
+    api_base: https://api.minimax.io/v1
+    temperature: 0.7
+```
+Get your API key at [MiniMax Platform](https://platform.minimax.io).
+
+### Z.ai Coding Plan
+
+```yaml
+llm:
+    provider: zai
+    model: "zai/glm-4.7"
+    api_key: your-zai-api-key
+    api_base: "https://api.z.ai/api/coding/paas/v4"
+```

--- a/README.md
+++ b/README.md
@@ -60,34 +60,7 @@ Before running any step, you need to configure your API keys:
 
 2. **Edit `config.user.yaml`** with your API keys:
    - See [LiteLLM providers](https://docs.litellm.ai/docs/providers) for the full list of supported providers
-   - Provider examples:
-
-   **OpenAI:**
-   ```yaml
-   llm:
-     provider: openai
-     model: gpt-4
-     api_key: sk-your-openai-api-key
-   ```
-
-   **MiniMax** (OpenAI-compatible, 204K context window):
-   ```yaml
-   llm:
-     provider: minimax
-     model: openai/MiniMax-M2.5        # or openai/MiniMax-M2.5-highspeed
-     api_key: your-minimax-api-key
-     api_base: https://api.minimax.io/v1
-     temperature: 0.7                   # must be in (0.0, 1.0]
-   ```
-   Get your API key at [MiniMax Platform](https://platform.minimax.io).
-
-   **Anthropic:**
-   ```yaml
-   llm:
-     provider: anthropic
-     model: claude-sonnet-4-20250514
-     api_key: sk-ant-your-anthropic-key
-   ```
+   - Check out [Provider Examples](PROVIDER_EXAMPLES.md) for some examples
 
 3. Just follow each steps, read and try it out.
 

--- a/default_workspace/config.example.yaml
+++ b/default_workspace/config.example.yaml
@@ -7,23 +7,6 @@ llm:
   temperature: 0.7
   max_tokens: 2048
 
-# --- Alternative provider examples ---
-
-# MiniMax (OpenAI-compatible, 204K context, get your key at https://platform.minimax.io)
-# llm:
-#   provider: minimax
-#   model: openai/MiniMax-M2.5           # or openai/MiniMax-M2.5-highspeed for faster output
-#   api_key: your-minimax-api-key
-#   api_base: https://api.minimax.io/v1
-#   temperature: 0.7                     # MiniMax requires temperature in (0.0, 1.0]
-#   max_tokens: 2048
-
-# Anthropic
-# llm:
-#   provider: anthropic
-#   model: claude-sonnet-4-20250514
-#   api_key: sk-ant-your-anthropic-key
-
 default_agent: pickle
 
 # Get your API key at https://brave.com/search/api/


### PR DESCRIPTION
## Summary

Add [MiniMax](https://platform.minimax.io) as a documented LLM provider option for the tutorial.

- Add MiniMax configuration example to `config.example.yaml` with model names, API base URL, and temperature constraints
- Add provider setup examples (OpenAI, MiniMax, Anthropic) to README.md for easier onboarding
- MiniMax offers an OpenAI-compatible API with 204K context window, working out of the box with LiteLLM via the `openai/` prefix

### MiniMax Configuration

```yaml
llm:
  provider: minimax
  model: openai/MiniMax-M2.5        # or openai/MiniMax-M2.5-highspeed
  api_key: your-minimax-api-key
  api_base: https://api.minimax.io/v1
  temperature: 0.7                   # must be in (0.0, 1.0]
```

No code changes needed — the existing LiteLLM integration handles MiniMax seamlessly via the OpenAI-compatible endpoint.
