### PR TITLE
Add provider examples for Anthropic, Qwen, Grok, and Gemini

### DIFF
--- a/PROVIDER_EXAMPLES.md
+++ b/PROVIDER_EXAMPLES.md
@@ -30,3 +30,47 @@ llm:
     api_key: your-zai-api-key
     api_base: "https://api.z.ai/api/coding/paas/v4"
 ```
+
+### Anthropic
+
+```yaml
+llm:
+    provider: anthropic
+    model: claude-sonnet-4-20250514
+    api_key: your-anthropic-api-key
+```
+Get your API key at [Anthropic Console](https://console.anthropic.com).
+
+### Qwen (OpenAI-compatible)
+
+```yaml
+llm:
+    provider: openai
+    model: qwen/qwen-max
+    api_key: your-dashscope-api-key
+    api_base: https://dashscope.aliyuncs.com/compatible-mode/v1
+    temperature: 0.7
+```
+Get your API key at [DashScope](https://dashscope.console.aliyun.com).
+
+### Grok (OpenAI-compatible)
+
+```yaml
+llm:
+    provider: openai
+    model: grok-2-1212
+    api_key: your-x-api-key
+    api_base: https://api.x.ai/v1
+    temperature: 0.7
+```
+Get your API key at [x.ai](https://console.x.ai).
+
+### Gemini (Google AI)
+
+```yaml
+llm:
+    provider: google
+    model: gemini-2.0-flash
+    api_key: your-google-api-key
+```
+Get your API key at [Google AI Studio](https://aistudio.google.com/app/apikey).


### PR DESCRIPTION
Fixes #6 - Add Provider Example Configuration

Added configuration examples for:
- Anthropic (claude-sonnet-4)
- Qwen via DashScope
- Grok via x.ai
- Gemini via Google AI Studio