### PR TITLE
Chore: Compaction Prompt Enhancement

### DIFF
--- a/05-compaction/src/mybot/core/context_guard.py
+++ b/05-compaction/src/mybot/core/context_guard.py
@@ -17,6 +17,26 @@ if TYPE_CHECKING:
 # Default max size for tool result content before truncation
 MAX_TOOL_RESULT_CHARS = 10000
 
+COMPACT_PROMPT = """Your task is to create a detailed summary of the conversation so far, capturing the user's requests, your actions, and any important context needed to continue without losing information.
+
+Your summary should include the following sections:
+
+1. Primary Request and Intent: What did the user explicitly ask for? Capture the full scope of their request.
+
+2. Key Facts and User Preferences: Important information exchanged, decisions made, and user preferences or constraints discovered during the conversation.
+
+3. User Messages: List ALL user messages that are not tool results. These are critical for understanding the user's feedback and changing intent.
+
+4. Errors and Corrections: Any mistakes made, how they were fixed, and especially any corrections or feedback from the user about doing things differently.
+
+5. Current Work and Pending Tasks: What was being worked on immediately before this summary, and what tasks remain unfinished.
+
+Here is the conversation to summarize:
+
+{conversation}
+
+Please provide your summary following this structure. Be precise and thorough — the next response will only have access to this summary, not the original messages."""
+
 
 @dataclass
 class ContextGuard:
@@ -112,9 +132,7 @@ class ContextGuard:
         old_messages = state.messages[:compress_count]
         old_text = self._serialize_messages_for_summary(old_messages)
 
-        summary_prompt = f"""Summarize the conversation so far. Keep it factual and concise. Focus on key decisions, facts, and user preferences discovered:
-
-{old_text}"""
+        summary_prompt = COMPACT_PROMPT.format(conversation=old_text)
 
         response, _ = await state.agent.llm.chat(
             [{"role": "user", "content": summary_prompt}],
@@ -132,7 +150,7 @@ class ContextGuard:
         messages.append(
             {
                 "role": "assistant",
-                "content": "Understood, I have the context.",
+                "content": "I've reviewed the conversation summary. Ready to continue.",
             }
         )
         messages.extend(state.messages[compress_count:])

--- a/06-web-tools/src/mybot/core/context_guard.py
+++ b/06-web-tools/src/mybot/core/context_guard.py
@@ -17,6 +17,26 @@ if TYPE_CHECKING:
 # Default max size for tool result content before truncation
 MAX_TOOL_RESULT_CHARS = 10000
 
+COMPACT_PROMPT = """Your task is to create a detailed summary of the conversation so far, capturing the user's requests, your actions, and any important context needed to continue without losing information.
+
+Your summary should include the following sections:
+
+1. Primary Request and Intent: What did the user explicitly ask for? Capture the full scope of their request.
+
+2. Key Facts and User Preferences: Important information exchanged, decisions made, and user preferences or constraints discovered during the conversation.
+
+3. User Messages: List ALL user messages that are not tool results. These are critical for understanding the user's feedback and changing intent.
+
+4. Errors and Corrections: Any mistakes made, how they were fixed, and especially any corrections or feedback from the user about doing things differently.
+
+5. Current Work and Pending Tasks: What was being worked on immediately before this summary, and what tasks remain unfinished.
+
+Here is the conversation to summarize:
+
+{conversation}
+
+Please provide your summary following this structure. Be precise and thorough — the next response will only have access to this summary, not the original messages."""
+
 
 @dataclass
 class ContextGuard:
@@ -112,9 +132,7 @@ class ContextGuard:
         old_messages = state.messages[:compress_count]
         old_text = self._serialize_messages_for_summary(old_messages)
 
-        summary_prompt = f"""Summarize the conversation so far. Keep it factual and concise. Focus on key decisions, facts, and user preferences discovered:
-
-{old_text}"""
+        summary_prompt = COMPACT_PROMPT.format(conversation=old_text)
 
         response, _ = await state.agent.llm.chat(
             [{"role": "user", "content": summary_prompt}],
@@ -132,7 +150,7 @@ class ContextGuard:
         messages.append(
             {
                 "role": "assistant",
-                "content": "Understood, I have the context.",
+                "content": "I've reviewed the conversation summary. Ready to continue.",
             }
         )
         messages.extend(state.messages[compress_count:])

--- a/07-event-driven/src/mybot/core/context_guard.py
+++ b/07-event-driven/src/mybot/core/context_guard.py
@@ -19,6 +19,26 @@ if TYPE_CHECKING:
 # Default max size for tool result content before truncation
 MAX_TOOL_RESULT_CHARS = 10000
 
+COMPACT_PROMPT = """Your task is to create a detailed summary of the conversation so far, capturing the user's requests, your actions, and any important context needed to continue without losing information.
+
+Your summary should include the following sections:
+
+1. Primary Request and Intent: What did the user explicitly ask for? Capture the full scope of their request.
+
+2. Key Facts and User Preferences: Important information exchanged, decisions made, and user preferences or constraints discovered during the conversation.
+
+3. User Messages: List ALL user messages that are not tool results. These are critical for understanding the user's feedback and changing intent.
+
+4. Errors and Corrections: Any mistakes made, how they were fixed, and especially any corrections or feedback from the user about doing things differently.
+
+5. Current Work and Pending Tasks: What was being worked on immediately before this summary, and what tasks remain unfinished.
+
+Here is the conversation to summarize:
+
+{conversation}
+
+Please provide your summary following this structure. Be precise and thorough — the next response will only have access to this summary, not the original messages."""
+
 
 @dataclass
 class ContextGuard:
@@ -115,9 +135,7 @@ class ContextGuard:
         old_messages = state.messages[:compress_count]
         old_text = self._serialize_messages_for_summary(old_messages)
 
-        summary_prompt = f"""Summarize the conversation so far. Keep it factual and concise. Focus on key decisions, facts, and user preferences discovered:
-
-{old_text}"""
+        summary_prompt = COMPACT_PROMPT.format(conversation=old_text)
 
         response, _ = await state.agent.llm.chat(
             [{"role": "user", "content": summary_prompt}],
@@ -135,7 +153,7 @@ class ContextGuard:
         messages.append(
             {
                 "role": "assistant",
-                "content": "Understood, I have the context.",
+                "content": "I've reviewed the conversation summary. Ready to continue.",
             }
         )
         messages.extend(state.messages[compress_count:])

--- a/08-config-hot-reload/src/mybot/core/context_guard.py
+++ b/08-config-hot-reload/src/mybot/core/context_guard.py
@@ -19,6 +19,26 @@ if TYPE_CHECKING:
 # Default max size for tool result content before truncation
 MAX_TOOL_RESULT_CHARS = 10000
 
+COMPACT_PROMPT = """Your task is to create a detailed summary of the conversation so far, capturing the user's requests, your actions, and any important context needed to continue without losing information.
+
+Your summary should include the following sections:
+
+1. Primary Request and Intent: What did the user explicitly ask for? Capture the full scope of their request.
+
+2. Key Facts and User Preferences: Important information exchanged, decisions made, and user preferences or constraints discovered during the conversation.
+
+3. User Messages: List ALL user messages that are not tool results. These are critical for understanding the user's feedback and changing intent.
+
+4. Errors and Corrections: Any mistakes made, how they were fixed, and especially any corrections or feedback from the user about doing things differently.
+
+5. Current Work and Pending Tasks: What was being worked on immediately before this summary, and what tasks remain unfinished.
+
+Here is the conversation to summarize:
+
+{conversation}
+
+Please provide your summary following this structure. Be precise and thorough — the next response will only have access to this summary, not the original messages."""
+
 
 @dataclass
 class ContextGuard:
@@ -115,9 +135,7 @@ class ContextGuard:
         old_messages = state.messages[:compress_count]
         old_text = self._serialize_messages_for_summary(old_messages)
 
-        summary_prompt = f"""Summarize the conversation so far. Keep it factual and concise. Focus on key decisions, facts, and user preferences discovered:
-
-{old_text}"""
+        summary_prompt = COMPACT_PROMPT.format(conversation=old_text)
 
         response, _ = await state.agent.llm.chat(
             [{"role": "user", "content": summary_prompt}],
@@ -135,7 +153,7 @@ class ContextGuard:
         messages.append(
             {
                 "role": "assistant",
-                "content": "Understood, I have the context.",
+                "content": "I've reviewed the conversation summary. Ready to continue.",
             }
         )
         messages.extend(state.messages[compress_count:])

--- a/09-channels/src/mybot/core/context_guard.py
+++ b/09-channels/src/mybot/core/context_guard.py
@@ -21,6 +21,26 @@ if TYPE_CHECKING:
 # Default max size for tool result content before truncation
 MAX_TOOL_RESULT_CHARS = 10000
 
+COMPACT_PROMPT = """Your task is to create a detailed summary of the conversation so far, capturing the user's requests, your actions, and any important context needed to continue without losing information.
+
+Your summary should include the following sections:
+
+1. Primary Request and Intent: What did the user explicitly ask for? Capture the full scope of their request.
+
+2. Key Facts and User Preferences: Important information exchanged, decisions made, and user preferences or constraints discovered during the conversation.
+
+3. User Messages: List ALL user messages that are not tool results. These are critical for understanding the user's feedback and changing intent.
+
+4. Errors and Corrections: Any mistakes made, how they were fixed, and especially any corrections or feedback from the user about doing things differently.
+
+5. Current Work and Pending Tasks: What was being worked on immediately before this summary, and what tasks remain unfinished.
+
+Here is the conversation to summarize:
+
+{conversation}
+
+Please provide your summary following this structure. Be precise and thorough — the next response will only have access to this summary, not the original messages."""
+
 
 @dataclass
 class ContextGuard:
@@ -131,9 +151,7 @@ class ContextGuard:
         old_messages = state.messages[:compress_count]
         old_text = self._serialize_messages_for_summary(old_messages)
 
-        summary_prompt = f"""Summarize the conversation so far. Keep it factual and concise. Focus on key decisions, facts, and user preferences discovered:
-
-{old_text}"""
+        summary_prompt = COMPACT_PROMPT.format(conversation=old_text)
 
         response, _ = await state.agent.llm.chat(
             [{"role": "user", "content": summary_prompt}],
@@ -150,7 +168,7 @@ class ContextGuard:
         messages.append(
             {
                 "role": "assistant",
-                "content": "Understood, I have the context.",
+                "content": "I've reviewed the conversation summary. Ready to continue.",
             }
         )
         messages.extend(state.messages[compress_count:])

--- a/10-websocket/src/mybot/core/context_guard.py
+++ b/10-websocket/src/mybot/core/context_guard.py
@@ -21,6 +21,26 @@ if TYPE_CHECKING:
 # Default max size for tool result content before truncation
 MAX_TOOL_RESULT_CHARS = 10000
 
+COMPACT_PROMPT = """Your task is to create a detailed summary of the conversation so far, capturing the user's requests, your actions, and any important context needed to continue without losing information.
+
+Your summary should include the following sections:
+
+1. Primary Request and Intent: What did the user explicitly ask for? Capture the full scope of their request.
+
+2. Key Facts and User Preferences: Important information exchanged, decisions made, and user preferences or constraints discovered during the conversation.
+
+3. User Messages: List ALL user messages that are not tool results. These are critical for understanding the user's feedback and changing intent.
+
+4. Errors and Corrections: Any mistakes made, how they were fixed, and especially any corrections or feedback from the user about doing things differently.
+
+5. Current Work and Pending Tasks: What was being worked on immediately before this summary, and what tasks remain unfinished.
+
+Here is the conversation to summarize:
+
+{conversation}
+
+Please provide your summary following this structure. Be precise and thorough — the next response will only have access to this summary, not the original messages."""
+
 
 @dataclass
 class ContextGuard:
@@ -131,9 +151,7 @@ class ContextGuard:
         old_messages = state.messages[:compress_count]
         old_text = self._serialize_messages_for_summary(old_messages)
 
-        summary_prompt = f"""Summarize the conversation so far. Keep it factual and concise. Focus on key decisions, facts, and user preferences discovered:
-
-{old_text}"""
+        summary_prompt = COMPACT_PROMPT.format(conversation=old_text)
 
         response, _ = await state.agent.llm.chat(
             [{"role": "user", "content": summary_prompt}],
@@ -150,7 +168,7 @@ class ContextGuard:
         messages.append(
             {
                 "role": "assistant",
-                "content": "Understood, I have the context.",
+                "content": "I've reviewed the conversation summary. Ready to continue.",
             }
         )
         messages.extend(state.messages[compress_count:])

--- a/11-multi-agent-routing/src/mybot/core/context_guard.py
+++ b/11-multi-agent-routing/src/mybot/core/context_guard.py
@@ -20,6 +20,26 @@ if TYPE_CHECKING:
 # Default max size for tool result content before truncation
 MAX_TOOL_RESULT_CHARS = 10000
 
+COMPACT_PROMPT = """Your task is to create a detailed summary of the conversation so far, capturing the user's requests, your actions, and any important context needed to continue without losing information.
+
+Your summary should include the following sections:
+
+1. Primary Request and Intent: What did the user explicitly ask for? Capture the full scope of their request.
+
+2. Key Facts and User Preferences: Important information exchanged, decisions made, and user preferences or constraints discovered during the conversation.
+
+3. User Messages: List ALL user messages that are not tool results. These are critical for understanding the user's feedback and changing intent.
+
+4. Errors and Corrections: Any mistakes made, how they were fixed, and especially any corrections or feedback from the user about doing things differently.
+
+5. Current Work and Pending Tasks: What was being worked on immediately before this summary, and what tasks remain unfinished.
+
+Here is the conversation to summarize:
+
+{conversation}
+
+Please provide your summary following this structure. Be precise and thorough — the next response will only have access to this summary, not the original messages."""
+
 
 @dataclass
 class ContextGuard:
@@ -132,9 +152,7 @@ class ContextGuard:
         old_messages = state.messages[:compress_count]
         old_text = self._serialize_messages_for_summary(old_messages)
 
-        summary_prompt = f"""Summarize the conversation so far. Keep it factual and concise. Focus on key decisions, facts, and user preferences discovered:
-
-{old_text}"""
+        summary_prompt = COMPACT_PROMPT.format(conversation=old_text)
 
         response, _ = await state.agent.llm.chat(
             [{"role": "user", "content": summary_prompt}],
@@ -151,7 +169,7 @@ class ContextGuard:
         messages.append(
             {
                 "role": "assistant",
-                "content": "Understood, I have the context.",
+                "content": "I've reviewed the conversation summary. Ready to continue.",
             }
         )
         messages.extend(state.messages[compress_count:])

--- a/12-cron-heartbeat/src/mybot/core/context_guard.py
+++ b/12-cron-heartbeat/src/mybot/core/context_guard.py
@@ -20,6 +20,26 @@ if TYPE_CHECKING:
 # Default max size for tool result content before truncation
 MAX_TOOL_RESULT_CHARS = 10000
 
+COMPACT_PROMPT = """Your task is to create a detailed summary of the conversation so far, capturing the user's requests, your actions, and any important context needed to continue without losing information.
+
+Your summary should include the following sections:
+
+1. Primary Request and Intent: What did the user explicitly ask for? Capture the full scope of their request.
+
+2. Key Facts and User Preferences: Important information exchanged, decisions made, and user preferences or constraints discovered during the conversation.
+
+3. User Messages: List ALL user messages that are not tool results. These are critical for understanding the user's feedback and changing intent.
+
+4. Errors and Corrections: Any mistakes made, how they were fixed, and especially any corrections or feedback from the user about doing things differently.
+
+5. Current Work and Pending Tasks: What was being worked on immediately before this summary, and what tasks remain unfinished.
+
+Here is the conversation to summarize:
+
+{conversation}
+
+Please provide your summary following this structure. Be precise and thorough — the next response will only have access to this summary, not the original messages."""
+
 
 @dataclass
 class ContextGuard:
@@ -132,9 +152,7 @@ class ContextGuard:
         old_messages = state.messages[:compress_count]
         old_text = self._serialize_messages_for_summary(old_messages)
 
-        summary_prompt = f"""Summarize the conversation so far. Keep it factual and concise. Focus on key decisions, facts, and user preferences discovered:
-
-{old_text}"""
+        summary_prompt = COMPACT_PROMPT.format(conversation=old_text)
 
         response, _ = await state.agent.llm.chat(
             [{"role": "user", "content": summary_prompt}],
@@ -151,7 +169,7 @@ class ContextGuard:
         messages.append(
             {
                 "role": "assistant",
-                "content": "Understood, I have the context.",
+                "content": "I've reviewed the conversation summary. Ready to continue.",
             }
         )
         messages.extend(state.messages[compress_count:])

--- a/13-multi-layer-prompts/src/mybot/core/context_guard.py
+++ b/13-multi-layer-prompts/src/mybot/core/context_guard.py
@@ -20,6 +20,26 @@ if TYPE_CHECKING:
 # Default max size for tool result content before truncation
 MAX_TOOL_RESULT_CHARS = 10000
 
+COMPACT_PROMPT = """Your task is to create a detailed summary of the conversation so far, capturing the user's requests, your actions, and any important context needed to continue without losing information.
+
+Your summary should include the following sections:
+
+1. Primary Request and Intent: What did the user explicitly ask for? Capture the full scope of their request.
+
+2. Key Facts and User Preferences: Important information exchanged, decisions made, and user preferences or constraints discovered during the conversation.
+
+3. User Messages: List ALL user messages that are not tool results. These are critical for understanding the user's feedback and changing intent.
+
+4. Errors and Corrections: Any mistakes made, how they were fixed, and especially any corrections or feedback from the user about doing things differently.
+
+5. Current Work and Pending Tasks: What was being worked on immediately before this summary, and what tasks remain unfinished.
+
+Here is the conversation to summarize:
+
+{conversation}
+
+Please provide your summary following this structure. Be precise and thorough — the next response will only have access to this summary, not the original messages."""
+
 
 @dataclass
 class ContextGuard:
@@ -132,9 +152,7 @@ class ContextGuard:
         old_messages = state.messages[:compress_count]
         old_text = self._serialize_messages_for_summary(old_messages)
 
-        summary_prompt = f"""Summarize the conversation so far. Keep it factual and concise. Focus on key decisions, facts, and user preferences discovered:
-
-{old_text}"""
+        summary_prompt = COMPACT_PROMPT.format(conversation=old_text)
 
         response, _ = await state.agent.llm.chat(
             [{"role": "user", "content": summary_prompt}],
@@ -151,7 +169,7 @@ class ContextGuard:
         messages.append(
             {
                 "role": "assistant",
-                "content": "Understood, I have the context.",
+                "content": "I've reviewed the conversation summary. Ready to continue.",
             }
         )
         messages.extend(state.messages[compress_count:])

--- a/14-post-message-back/src/mybot/core/context_guard.py
+++ b/14-post-message-back/src/mybot/core/context_guard.py
@@ -20,6 +20,26 @@ if TYPE_CHECKING:
 # Default max size for tool result content before truncation
 MAX_TOOL_RESULT_CHARS = 10000
 
+COMPACT_PROMPT = """Your task is to create a detailed summary of the conversation so far, capturing the user's requests, your actions, and any important context needed to continue without losing information.
+
+Your summary should include the following sections:
+
+1. Primary Request and Intent: What did the user explicitly ask for? Capture the full scope of their request.
+
+2. Key Facts and User Preferences: Important information exchanged, decisions made, and user preferences or constraints discovered during the conversation.
+
+3. User Messages: List ALL user messages that are not tool results. These are critical for understanding the user's feedback and changing intent.
+
+4. Errors and Corrections: Any mistakes made, how they were fixed, and especially any corrections or feedback from the user about doing things differently.
+
+5. Current Work and Pending Tasks: What was being worked on immediately before this summary, and what tasks remain unfinished.
+
+Here is the conversation to summarize:
+
+{conversation}
+
+Please provide your summary following this structure. Be precise and thorough — the next response will only have access to this summary, not the original messages."""
+
 
 @dataclass
 class ContextGuard:
@@ -132,9 +152,7 @@ class ContextGuard:
         old_messages = state.messages[:compress_count]
         old_text = self._serialize_messages_for_summary(old_messages)
 
-        summary_prompt = f"""Summarize the conversation so far. Keep it factual and concise. Focus on key decisions, facts, and user preferences discovered:
-
-{old_text}"""
+        summary_prompt = COMPACT_PROMPT.format(conversation=old_text)
 
         response, _ = await state.agent.llm.chat(
             [{"role": "user", "content": summary_prompt}],
@@ -151,7 +169,7 @@ class ContextGuard:
         messages.append(
             {
                 "role": "assistant",
-                "content": "Understood, I have the context.",
+                "content": "I've reviewed the conversation summary. Ready to continue.",
             }
         )
         messages.extend(state.messages[compress_count:])

--- a/15-agent-dispatch/src/mybot/core/context_guard.py
+++ b/15-agent-dispatch/src/mybot/core/context_guard.py
@@ -20,6 +20,26 @@ if TYPE_CHECKING:
 # Default max size for tool result content before truncation
 MAX_TOOL_RESULT_CHARS = 10000
 
+COMPACT_PROMPT = """Your task is to create a detailed summary of the conversation so far, capturing the user's requests, your actions, and any important context needed to continue without losing information.
+
+Your summary should include the following sections:
+
+1. Primary Request and Intent: What did the user explicitly ask for? Capture the full scope of their request.
+
+2. Key Facts and User Preferences: Important information exchanged, decisions made, and user preferences or constraints discovered during the conversation.
+
+3. User Messages: List ALL user messages that are not tool results. These are critical for understanding the user's feedback and changing intent.
+
+4. Errors and Corrections: Any mistakes made, how they were fixed, and especially any corrections or feedback from the user about doing things differently.
+
+5. Current Work and Pending Tasks: What was being worked on immediately before this summary, and what tasks remain unfinished.
+
+Here is the conversation to summarize:
+
+{conversation}
+
+Please provide your summary following this structure. Be precise and thorough — the next response will only have access to this summary, not the original messages."""
+
 
 @dataclass
 class ContextGuard:
@@ -132,9 +152,7 @@ class ContextGuard:
         old_messages = state.messages[:compress_count]
         old_text = self._serialize_messages_for_summary(old_messages)
 
-        summary_prompt = f"""Summarize the conversation so far. Keep it factual and concise. Focus on key decisions, facts, and user preferences discovered:
-
-{old_text}"""
+        summary_prompt = COMPACT_PROMPT.format(conversation=old_text)
 
         response, _ = await state.agent.llm.chat(
             [{"role": "user", "content": summary_prompt}],
@@ -151,7 +169,7 @@ class ContextGuard:
         messages.append(
             {
                 "role": "assistant",
-                "content": "Understood, I have the context.",
+                "content": "I've reviewed the conversation summary. Ready to continue.",
             }
         )
         messages.extend(state.messages[compress_count:])

--- a/16-concurrency-control/src/mybot/core/context_guard.py
+++ b/16-concurrency-control/src/mybot/core/context_guard.py
@@ -20,6 +20,26 @@ if TYPE_CHECKING:
 # Default max size for tool result content before truncation
 MAX_TOOL_RESULT_CHARS = 10000
 
+COMPACT_PROMPT = """Your task is to create a detailed summary of the conversation so far, capturing the user's requests, your actions, and any important context needed to continue without losing information.
+
+Your summary should include the following sections:
+
+1. Primary Request and Intent: What did the user explicitly ask for? Capture the full scope of their request.
+
+2. Key Facts and User Preferences: Important information exchanged, decisions made, and user preferences or constraints discovered during the conversation.
+
+3. User Messages: List ALL user messages that are not tool results. These are critical for understanding the user's feedback and changing intent.
+
+4. Errors and Corrections: Any mistakes made, how they were fixed, and especially any corrections or feedback from the user about doing things differently.
+
+5. Current Work and Pending Tasks: What was being worked on immediately before this summary, and what tasks remain unfinished.
+
+Here is the conversation to summarize:
+
+{conversation}
+
+Please provide your summary following this structure. Be precise and thorough — the next response will only have access to this summary, not the original messages."""
+
 
 @dataclass
 class ContextGuard:
@@ -132,9 +152,7 @@ class ContextGuard:
         old_messages = state.messages[:compress_count]
         old_text = self._serialize_messages_for_summary(old_messages)
 
-        summary_prompt = f"""Summarize the conversation so far. Keep it factual and concise. Focus on key decisions, facts, and user preferences discovered:
-
-{old_text}"""
+        summary_prompt = COMPACT_PROMPT.format(conversation=old_text)
 
         response, _ = await state.agent.llm.chat(
             [{"role": "user", "content": summary_prompt}],
@@ -151,7 +169,7 @@ class ContextGuard:
         messages.append(
             {
                 "role": "assistant",
-                "content": "Understood, I have the context.",
+                "content": "I've reviewed the conversation summary. Ready to continue.",
             }
         )
         messages.extend(state.messages[compress_count:])

--- a/17-memory/src/mybot/core/context_guard.py
+++ b/17-memory/src/mybot/core/context_guard.py
@@ -20,6 +20,26 @@ if TYPE_CHECKING:
 # Default max size for tool result content before truncation
 MAX_TOOL_RESULT_CHARS = 10000
 
+COMPACT_PROMPT = """Your task is to create a detailed summary of the conversation so far, capturing the user's requests, your actions, and any important context needed to continue without losing information.
+
+Your summary should include the following sections:
+
+1. Primary Request and Intent: What did the user explicitly ask for? Capture the full scope of their request.
+
+2. Key Facts and User Preferences: Important information exchanged, decisions made, and user preferences or constraints discovered during the conversation.
+
+3. User Messages: List ALL user messages that are not tool results. These are critical for understanding the user's feedback and changing intent.
+
+4. Errors and Corrections: Any mistakes made, how they were fixed, and especially any corrections or feedback from the user about doing things differently.
+
+5. Current Work and Pending Tasks: What was being worked on immediately before this summary, and what tasks remain unfinished.
+
+Here is the conversation to summarize:
+
+{conversation}
+
+Please provide your summary following this structure. Be precise and thorough — the next response will only have access to this summary, not the original messages."""
+
 
 @dataclass
 class ContextGuard:
@@ -132,9 +152,7 @@ class ContextGuard:
         old_messages = state.messages[:compress_count]
         old_text = self._serialize_messages_for_summary(old_messages)
 
-        summary_prompt = f"""Summarize the conversation so far. Keep it factual and concise. Focus on key decisions, facts, and user preferences discovered:
-
-{old_text}"""
+        summary_prompt = COMPACT_PROMPT.format(conversation=old_text)
 
         response, _ = await state.agent.llm.chat(
             [{"role": "user", "content": summary_prompt}],
@@ -151,7 +169,7 @@ class ContextGuard:
         messages.append(
             {
                 "role": "assistant",
-                "content": "Understood, I have the context.",
+                "content": "I've reviewed the conversation summary. Ready to continue.",
             }
         )
         messages.extend(state.messages[compress_count:])


### PR DESCRIPTION
## Summary

- Replace the inline conversation summary prompt with a structured `COMPACT_PROMPT` constant that produces richer, more detailed summaries with explicit sections (primary request, key facts, user messages, errors/corrections, pending tasks).
- Update the placeholder assistant message after compaction from "Understood, I have the context." to "I have reviewed the conversation summary. Ready to continue."
- Changes applied consistently across all 13 chapter copies of `context_guard.py` (chapters 05-17).

## Why

The original summary prompt was minimal — "Summarize the conversation so far. Keep it factual and concise." This often produced shallow summaries that lost important context after compaction. The new prompt explicitly asks the LLM to capture user intent, all user messages, errors and corrections, and pending work, which are the things most likely to be lost and most critical to preserve.