### PR TITLE
docs: update MiniMax example to M3

### DIFF
--- a/PROVIDER_EXAMPLES.md
+++ b/PROVIDER_EXAMPLES.md
@@ -14,7 +14,7 @@ llm:
 ```yaml
 llm:
     provider: minimax
-    model: openai/MiniMax-M2.5
+    model: openai/MiniMax-M3
     api_key: your-minimax-api-key
     api_base: https://api.minimax.io/v1
     temperature: 0.7


### PR DESCRIPTION
## Summary

The MiniMax provider example in `PROVIDER_EXAMPLES.md` still pointed at `MiniMax-M2.5`, while M3 is now the recommended general-purpose model on the [MiniMax Platform](https://platform.minimax.io). This bumps that one example so users following the tutorial get the current default out of the box.

## Changes

- `PROVIDER_EXAMPLES.md`: `openai/MiniMax-M2.5` -> `openai/MiniMax-M3` in the MiniMax config block

No other files mention a MiniMax model. The `provider: minimax` listing in `default_workspace/config.example.yaml` is left untouched (it does not pin a model). API base, key placeholder, and temperature are unchanged.

## Test plan

- [x] `rg -i "MiniMax-M"` shows only the new `MiniMax-M3` reference
- [x] No change to API URL, env vars, or other providers