### PR TITLE
Add DeepSeek provider example to documentation

### DIFF
--- a/PROVIDER_EXAMPLES.md
+++ b/PROVIDER_EXAMPLES.md
@@ -74,3 +74,15 @@ llm:
     api_key: your-google-api-key
 ```
 Get your API key at [Google AI Studio](https://aistudio.google.com/app/apikey).
+
+### DeepSeek
+
+```yaml
+llm:
+    provider: deepseek
+    model: deepseek/deepseek-v4-flash # or "deepseek-deepseek-v4-pro"
+    api_key: sk-your-deepseek-api-key
+    api_base: https://api.deepseek.com
+
+Get your API key at [Deepseek](https://platform.deepseek.com/)
+```

--- a/PROVIDER_EXAMPLES.md
+++ b/PROVIDER_EXAMPLES.md
@@ -80,7 +80,7 @@ Get your API key at [Google AI Studio](https://aistudio.google.com/app/apikey).
 ```yaml
 llm:
     provider: deepseek
-    model: deepseek/deepseek-v4-flash # or "deepseek-deepseek-v4-pro"
+    model: deepseek/deepseek-v4-flash # or "deepseek/deepseek-v4-pro"
     api_key: sk-your-deepseek-api-key
     api_base: https://api.deepseek.com
 


### PR DESCRIPTION
Added DeepSeek provider example with API key instructions.

Proposed in #12 