### PR TITLE
docs(providers): document MiniMax M2.7 and China endpoint

### DIFF
--- a/PROVIDER_EXAMPLES.md
+++ b/PROVIDER_EXAMPLES.md
@@ -21,6 +21,31 @@ llm:
 ```
 Get your API key at [MiniMax Platform](https://platform.minimax.io).
 
+#### MiniMax M2.7
+
+```yaml
+llm:
+    provider: minimax
+    model: openai/MiniMax-M2.7
+    api_key: your-minimax-api-key
+    api_base: https://api.minimax.io/v1
+    temperature: 0.7
+```
+
+#### MiniMax China endpoint
+
+The China endpoint is served from `api.minimaxi.com` and is recommended for
+access from within mainland China.
+
+```yaml
+llm:
+    provider: minimax
+    model: openai/MiniMax-M3
+    api_key: your-minimax-api-key
+    api_base: https://api.minimaxi.com/v1
+    temperature: 0.7
+```
+
 ### Z.ai Coding Plan
 
 ```yaml


### PR DESCRIPTION
Reason: Refresh the maintained MiniMax provider configuration to document the MiniMax-M2.7 model and the China endpoint while preserving the existing global MiniMax-M3 configuration.

Changes:
- Add a MiniMax M2.7 example using the global endpoint (`https://api.minimax.io/v1`).
- Add a MiniMax China endpoint example using `https://api.minimaxi.com/v1`, recommended for access from within mainland China.
- Preserve the existing global MiniMax-M3 example unchanged.

Checks:
- Verified the diff contains no secrets via the secret scan.
- Confirmed the Markdown/YAML examples render as valid fenced code blocks.
